### PR TITLE
👷 Move to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: Node.js ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node:
+        - 10
+        - 12
+        - 14
+    services:
+      redis:
+        image: redis
+        ports:
+        - 6379:6379
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install
+      run: npm install
+    - name: Test
+      run: npm run test-cover
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: node-${{ matrix.node }}
+        parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit coverage
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-  - "10"
-  - "8"
-services: redis-server
-script: "npm run test-cover"
-# Send coverage data to Coveralls
-after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "nyc": "^14.1.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "test-cover": "node_modules/nyc/bin/nyc.js --temp-dir=coverage -r text -r lcov node_modules/mocha/bin/_mocha"
+    "test": "mocha",
+    "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm test"
   },
   "repository": "git://github.com/share/sharedb-redis-pubsub.git",
   "author": "Nate Smith",


### PR DESCRIPTION
This change is a read-across of: https://github.com/share/sharedb/pull/409

It moves us on to Github Actions, because Travis has been pretty slow
lately. Github Actions is also free for public repositories and is (for
now) much faster than Travis.

While we're here, we also update our tested Node and MongoDB versions
in-line with their respective LTS schedules.