### PR TITLE
🙈 Ignore `package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.DS_Store
 node_modules
 coverage
+package-lock.json


### PR DESCRIPTION
The lockfile is ignored when apps use libraries, so we shouldn't include
this in our commits.