### PR TITLE
⬆️ Support `redis` v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^1.5.0",
-    "redis": "^2.6.0",
+    "redis": "^2.6.0 || ^3.0.0",
     "sharedb": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/share/sharedb-redis-pubsub/issues/11

This change adds support for `redis` v3. The breaking changes are listed
[here][1].

`sharedb-redis-pubsub` does not rely on any of the removed options.

[1]: https://github.com/NodeRedis/node-redis/releases/tag/v3.0.0