### PR TITLE
Dependency updates - sharedb@2, mocha@9, nyc@15; remove async (unused)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         - 10
         - 12
         - 14
+        - 16
     services:
       redis:
         image: redis

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,2 @@
+reporter: spec
+check-leaks: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "redis": "^2.6.0 || ^3.0.0",
-    "sharedb": "^1.0.0"
+    "sharedb": "^1.0.0 || ^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Redis pub/sub adapter adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "async": "^1.5.0",
     "redis": "^2.6.0 || ^3.0.0",
     "sharedb": "^1.0.0 || ^2.0.0"
   },
@@ -13,8 +12,8 @@
     "coveralls": "^3.0.7",
     "eslint": "^7.23.0",
     "eslint-config-google": "^0.14.0",
-    "mocha": "^6.2.2",
-    "nyc": "^14.1.1"
+    "mocha": "^9.1.1",
+    "nyc": "^15.1.0"
   },
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---reporter spec
---check-leaks


### PR DESCRIPTION
- sharedb@2 dropped support for Node 10. This library still technically works with sharedb@1 and Node 10, so keep support for them for now.
- Update testing libraries mocha and nyc to latest, includes switch to mocharc file from mocha.opts
- Remove unused `async` dependency