### PR TITLE
Add CI testing for Node 18, drop Node 10 and 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - 10
-        - 12
         - 14
         - 16
+        - 18
     services:
       redis:
         image: redis

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "redis": "^2.6.0 || ^3.0.0",
-    "sharedb": "^1.0.0 || ^2.0.0"
+    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Node 12 reached end-of-life on 2022-04-30, and Node 18 was promoted to an active release as of 2022-04-19.

sharedb@3 does the same thing, adding Node 18 and dropping Node 12.