### PR TITLE
Drop Node 14 from CI, add Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - 14
         - 16
         - 18
+        - 20
     services:
       redis:
         image: redis

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "redis": "^2.6.0 || ^3.0.0",
-    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
According to the Node.js [release schedule](https://nodejs.dev/en/about/releases/):

* v14 will be end-of-lifed on 30 April
* v20 has been released

This change drops v14 from our test matrix, and adds v20.

It also adds sharedb@4 to the supported sharedb core versions. sharedb@4 will do the same thing, add Node 20 and drop Node 14, with no actual breaking changes.
