### PR TITLE
💥 Bump `redis` to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "sharedb-redis-pubsub",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Redis pub/sub adapter adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "redis": "^2.6.0 || ^3.0.0",
+    "redis": "^4.0.0",
     "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,44 @@
 var redisPubSub = require('../index');
+var redis = require('redis');
+var runTestSuite = require('sharedb/test/pubsub');
 
-require('sharedb/test/pubsub')(function(callback) {
-  callback(null, redisPubSub());
+describe('default options', function() {
+  runTestSuite(function(callback) {
+    callback(null, redisPubSub());
+  });
+});
+
+describe('unconnected client', function() {
+  runTestSuite(function(callback) {
+    callback(null, redisPubSub({
+      client: redis.createClient()
+    }));
+  });
+});
+
+describe('connected client', function() {
+  var client;
+
+  beforeEach(function(done) {
+    client = redis.createClient();
+    client.connect().then(function() {
+      done();
+    }, done);
+  });
+
+  runTestSuite(function(callback) {
+    callback(null, redisPubSub({
+      client: client
+    }));
+  });
+});
+
+describe('connecting client', function() {
+  runTestSuite(function(callback) {
+    var client = redis.createClient();
+    client.connect();
+    callback(null, redisPubSub({
+      client: client
+    }));
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/share/sharedb-redis-pubsub/issues/19

This is a **BREAKING** change that upgrades the underlying `redis` client to v4, which had so many [breaking changes][1], that it's infeasible to maintain backwards-compatibility with v3. If consumers need to use v3, they are advised to pin their version of `sharedb-redis-pubsub` to v4.

This change adapts to the breakages:

 - wrap the returned `Promise`s in callbacks
 - actively connect the `client`, which no longer auto-connects
 - move the `message` event handler into the subscription callback
 - adapt to the new call signature of `client.eval()`

[1]: https://github.com/redis/node-redis/blob/HEAD/docs/v3-to-v4.md