### PR TITLE
💥 Drop support for version 16 and 18 of node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - 16
-        - 18
         - 20
+        - 22
+        - 24
     services:
       redis:
         image: redis

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharedb-redis-pubsub",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Redis pub/sub adapter adapter for ShareDB",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Node 16 and 18 are already end of life stage. Let's remove them from tests and let's add newer versions of node like 22 and 24