### PR TITLE
🐛 Fix double-close of a shared client

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,8 @@ var PUBLISH_SCRIPT =
   'end';
 
 function close(client) {
+  if (!client.isOpen) return Promise.resolve();
+
   if (client.close) {
     return client.close();
   }


### PR DESCRIPTION
At the moment, calling `close()` on a client that has already been closed throws `The client is closed`. This surfaces intermittently in CI when a `client` is shared between multiple `RedisPubSub` instances: the first instance to close tears the client down, and any subsequent instance closing the same client then throws.

It's a race in practice — `pubsub.close()` without a callback is fire-and-forget, so a later `close()` can land after the shared client is already gone.

This change guards `close()` on `client.isOpen`, mirroring the existing `connect()` helper, and early returns a resolved `Promise` when the client is already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

