### PR TITLE
⬆️ Support `redis@6`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         redis:
         - 4
         - 5
+        - 6
     services:
       redis:
         image: redis

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Redis pub/sub adapter adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "redis": "^4.0.0 || ^5.0.0",
+    "redis": "^4.0.0 || ^5.0.0 || ^6.0.0",
     "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change widens the supported `redis` range to include v6 alongside v4 and v5, and adds v6 to the CI test matrix.

No adapter changes were needed: every node-redis API we use (`createClient`, `client.options`, `connect()`, `subscribe()`, `unsubscribe()`, `eval()`, and `close()`) is unchanged in v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
